### PR TITLE
Fix xpath for menu url catching

### DIFF
--- a/plugins/komida_parser.py
+++ b/plugins/komida_parser.py
@@ -44,7 +44,7 @@ def get_menu_url(campus):
 
     try:
         page = lxml.html.fromstring(r_komida.content)
-        url = page.xpath('//h2[contains(text(), "{}")]/following::p[1]/a/@href'.format(campus_id[campus]))[0]
+        url = page.xpath('//h2[contains(text(), "{}")]/following::li[1]/a/@href'.format(campus_id[campus]))[0]
         url = urllib.parse.urljoin('https://www.uantwerpen.be/', url)
         logging.debug('Retrieved menu url for campus {}: <{}>'.format(campus.upper(), url))
 


### PR DESCRIPTION
Changes `<p>` tag to a `<li>` tag in the xpath URL catcher to reflect the updated komida website.